### PR TITLE
Unnecessary Locks

### DIFF
--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -216,24 +216,24 @@ class SquadQueue(commands.Cog):
     async def drop(self, interaction: discord.Interaction):
         """Remove user from mogi"""
         await interaction.response.defer()
-        async with self.LOCK:
-            mogi = self.get_mogi(interaction)
-            if mogi is None or not mogi.started or not mogi.gathering:
-                await interaction.followup.send("Queue has not started yet.")
-                return
+        
+        mogi = self.get_mogi(interaction)
+        if mogi is None or not mogi.started or not mogi.gathering:
+            await interaction.followup.send("Queue has not started yet.")
+            return
 
-            member = interaction.user
-            squad = mogi.check_player(member)
-            if squad is None:
-                await interaction.followup.send(f"{member.display_name} is not currently in this event; type `/c` to join")
-                return
-            mogi.teams.remove(squad)
-            msg = "Removed "
-            msg += ", ".join([p.lounge_name for p in squad.players])
-            msg += f" from the mogi {discord.utils.format_dt(mogi.start_time, style='R')}"
-            msg += f", `[{mogi.count_registered()} players]`"
+        member = interaction.user
+        squad = mogi.check_player(member)
+        if squad is None:
+            await interaction.followup.send(f"{member.display_name} is not currently in this event; type `/c` to join")
+            return
+        mogi.teams.remove(squad)
+        msg = "Removed "
+        msg += ", ".join([p.lounge_name for p in squad.players])
+        msg += f" from the mogi {discord.utils.format_dt(mogi.start_time, style='R')}"
+        msg += f", `[{mogi.count_registered()} players]`"
 
-            await interaction.followup.send(msg)
+        await interaction.followup.send(msg)
 
     @app_commands.command(name="sub")
     @app_commands.guild_only()

--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -173,43 +173,50 @@ class SquadQueue(commands.Cog):
     async def can(self, interaction: discord.Interaction):
         """Join a mogi"""
         await interaction.response.defer()
-        async with self.LOCK:
-            member = interaction.user
-            mogi = self.get_mogi(interaction)
-            if mogi is None or not mogi.started or not mogi.gathering:
-                await interaction.followup.send("Queue has not started yet.")
-                return
+        member = interaction.user
+        mogi = self.get_mogi(interaction)
+        if mogi is None or not mogi.started or not mogi.gathering:
+            await interaction.followup.send("Queue has not started yet.")
+            return
 
-            player_team = mogi.check_player(member)
+        player_team = mogi.check_player(member)
+        if player_team is not None:
+            await interaction.followup.send(f"{interaction.user.mention} is already signed up.")
+            return
 
-            if player_team is not None:
-                await interaction.followup.send(f"{interaction.user.mention} is already signed up.")
-                return
+        players = await mk8dx_150cc_mmr(self.URL, [member])
 
-            players = await mk8dx_150cc_mmr(self.URL, [member])
-
-            if len(players) == 0 or players[0] is None:
-                msg = f"{interaction.user.mention} fetch for MMR has failed and joining the queue was unsuccessful.  "
-                msg += "Please try again.  If the problem continues then contact a staff member for help."
-                await interaction.followup.send(msg)
-                return
-
-            msg = ""
-            if players[0].mmr is None:
-                starting_player_mmr = 1500
-                players[0].mmr = starting_player_mmr
-                msg += f"{players[0].lounge_name} is assumed to be a new player and will be playing this mogi with a starting MMR of {starting_player_mmr}.  "
-                msg += "If you believe this is a mistake, please contact a staff member for help.\n"
-
-            players[0].confirmed = True
-            squad = Team(players)
-            mogi.teams.append(squad)
-
-            msg += f"{players[0].lounge_name} joined queue closing at {discord.utils.format_dt(mogi.start_time - (self.QUEUE_OPEN_TIME - self.JOINING_TIME))}, `[{mogi.count_registered()} players]`"
-
+        # Since we have removed the asyncio lock,
+        # a second check is added to address the only possible race condition.
+        # This addresses if the player in question joined the queue with a 2nd command while we
+        # were pulling their rating
+        player_team = mogi.check_player(member)
+        if player_team is not None:
+            await interaction.followup.send(f"{interaction.user.mention} is already signed up.")
+            return
+        
+        if len(players) == 0 or players[0] is None:
+            msg = f"{interaction.user.mention} fetch for MMR has failed and joining the queue was unsuccessful.  "
+            msg += "Please try again.  If the problem continues then contact a staff member for help."
             await interaction.followup.send(msg)
-            await self.check_room_channels(mogi)
-            await self.check_num_teams(mogi)
+            return
+
+        msg = ""
+        if players[0].mmr is None:
+            starting_player_mmr = 1500
+            players[0].mmr = starting_player_mmr
+            msg += f"{players[0].lounge_name} is assumed to be a new player and will be playing this mogi with a starting MMR of {starting_player_mmr}.  "
+            msg += "If you believe this is a mistake, please contact a staff member for help.\n"
+
+        players[0].confirmed = True
+        squad = Team(players)
+        mogi.teams.append(squad)
+
+        msg += f"{players[0].lounge_name} joined queue closing at {discord.utils.format_dt(mogi.start_time - (self.QUEUE_OPEN_TIME - self.JOINING_TIME))}, `[{mogi.count_registered()} players]`"
+
+        await interaction.followup.send(msg)
+        await self.check_room_channels(mogi)
+        await self.check_num_teams(mogi)
 
     @app_commands.command(name="d")
     @app_commands.guild_only()


### PR DESCRIPTION
The goal of these changes is to eliminate unnecessarily obtaining asyncio locks, and thus creating bottlenecks and slowing down code execution. In particular, when many players are queueing and dropping, it is critical to optimize asyncio lock usage, or the bot will lag/process player additions/removals slowly.

The lock usage is far too broad and encloses things that do not need to be locked, reversing the benefits of asynchronous programming. So, at a bare minimum, we should lock only the few lines that need to be locked. Better yet, we drop the locks entirely and address any and all possible race conditions.

As of June 7th, 2024, no tests have been run. The code might also have syntax errors as it was written on a mobile.