### PR TITLE
Save MMR threshold, add /ping_staff command

### DIFF
--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -26,7 +26,7 @@ MMR_THRESHOLD_PKL = "mmr_threshold.pkl"
 
 class SquadQueue(commands.Cog):
     def __init__(self, bot):
-        self.bot = bot
+        self.bot: commands.Bot = bot
 
         self.next_event: Mogi = None
 
@@ -47,7 +47,7 @@ class SquadQueue(commands.Cog):
 
         self.LAUNCH_NEW_EVENTS = True
 
-        self.GUILD = None
+        self.GUILD: discord.Guild = None
 
         self.MOGI_CHANNEL = None
 
@@ -231,7 +231,7 @@ class SquadQueue(commands.Cog):
                 players.append(player)
                 msg += f"{players[0].lounge_name} is assumed to be a new player and will be playing this mogi with a starting MMR of {starting_player_mmr}.  "
                 msg += "If you believe this is a mistake, please contact a staff member for help.\n"
-            else:    
+            else:
                 players = await mkw_mmr(self.URL, [member], self.TRACK_TYPE)
 
                 if len(players) == 0 or players[0] is None:
@@ -291,7 +291,7 @@ class SquadQueue(commands.Cog):
                 f"You are still on cooldown. Please wait for {int(2 * 60 - (current_time - lastCommandTime))} more seconds to use this command again.",
                 ephemeral=True)
             return
-        
+
         is_room_thread = False
         room = None
         bottom_room_num = 1
@@ -472,7 +472,7 @@ class SquadQueue(commands.Cog):
         """Mogis will begin to be scheduled again.  Staff use only."""
         self.LAUNCH_NEW_EVENTS = True
         await interaction.response.send_message("Mogis will resume scheduling.")
-    
+
     @app_commands.command(name="change_event_time")
     @app_commands.guild_only()
     async def change_event_time(self, interaction: discord.Interaction, event_time: int):
@@ -570,7 +570,7 @@ class SquadQueue(commands.Cog):
         self.sq_times = []
 
         await interaction.response.send_message("Cleared list of Squad Queue Times.")
-    
+
     @app_commands.command(name="update_tier_info")
     @app_commands.guild_only()
     async def update_tier_info(self, interaction: discord.Interaction):
@@ -781,7 +781,7 @@ class SquadQueue(commands.Cog):
             except Exception as e:
                 print("Late Player message has failed to send.", flush=True)
                 print(traceback.format_exc())
-    
+
         # We could have used asyncio.call_later(120, handle_voting_and_history)
         # and removed asyncio.sleep(120) in handle_voting_and_history
         asyncio.create_task(SquadQueue.handle_voting_and_history(self.ongoing_event, self.HISTORY_CHANNEL))
@@ -990,7 +990,7 @@ class SquadQueue(commands.Cog):
             return
 
 
-async def setup(bot):
+async def setup(bot: commands.Bot):
     await bot.add_cog(SquadQueue(bot))
 
 

--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -70,7 +70,8 @@ class SquadQueue(commands.Cog):
         self.room_mmr_threshold = bot.config["ROOM_MMR_THRESHOLD"]
         if os.path.isfile(MMR_THRESHOLD_PKL):
             try:
-                self.room_mmr_threshold = dill.load('name_model.pkl')
+                with open(MMR_THRESHOLD_PKL, 'rb') as f:
+                    self.room_mmr_threshold = dill.load(f)
             except:
                 print(traceback.format_exc())
 

--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -924,7 +924,6 @@ class SquadQueue(commands.Cog):
                 return
             next_event_open_time = self.compute_next_event_open_time()
             next_event_start_time = next_event_open_time + self.JOINING_TIME
-            print(f"Next event open time: {next_event_open_time}", flush=True)
             # We don't want to schedule the next event if it would open after it's joining period and during its extension period
             if next_event_start_time < datetime.now(timezone.utc):
                 return

--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -14,12 +14,15 @@ import asyncio
 from collections import defaultdict
 from typing import Dict, List
 import traceback
+import os
+import dill
 
 headers = {'Content-type': 'application/json'}
 
 # Scheduled_Event = collections.namedtuple('Scheduled_Event', 'size time started mogi_channel')
 
 cooldowns = defaultdict(int)
+MMR_THRESHOLD_PKL = "mmr_threshold.pkl"
 
 class SquadQueue(commands.Cog):
     def __init__(self, bot):
@@ -65,6 +68,11 @@ class SquadQueue(commands.Cog):
         self.SUB_MESSAGE_LIFETIME_SECONDS = bot.config["SUB_MESSAGE_LIFETIME_SECONDS"]
 
         self.room_mmr_threshold = bot.config["ROOM_MMR_THRESHOLD"]
+        if os.path.isfile(MMR_THRESHOLD_PKL):
+            try:
+                self.room_mmr_threshold = dill.load('name_model.pkl')
+            except:
+                print(traceback.format_exc())
 
         self.TRACK_TYPE = bot.config["track_type"]
 
@@ -481,6 +489,11 @@ class SquadQueue(commands.Cog):
     async def change_mmr_threshold(self, interaction: discord.Interaction, mmr_threshold: int):
         """Change the maximum MMR gap allowed for a room."""
         self.room_mmr_threshold = mmr_threshold
+        try:
+            with open(MMR_THRESHOLD_PKL, 'wb') as f:
+                dill.dump(self.room_mmr_threshold, f)
+        except:
+            print(traceback.format_exc())
         await interaction.response.send_message(f"MMR Threshold for Queue Rooms has been modified to {mmr_threshold} MMR.")
 
     @app_commands.command(name="peek_bot_config")

--- a/ct_config.json
+++ b/ct_config.json
@@ -44,6 +44,8 @@
         792891432301625364,
         521149807994208295
     ],
+    "restricted_role_id": 797208908153618452,
+    "muted_role_id": 434887701662007296,
     "queue_messages": true,
     "sec_between_queue_msgs": 2,
     "username": "username",

--- a/ct_config.json
+++ b/ct_config.json
@@ -39,6 +39,11 @@
             792891432301625364,
             877629421811540016
     ],
+    "helper_staff_roles": [
+        520808674411937792,
+        792891432301625364,
+        521149807994208295
+    ],
     "queue_messages": true,
     "sec_between_queue_msgs": 2,
     "username": "username",

--- a/lounge.py
+++ b/lounge.py
@@ -50,6 +50,13 @@ async def on_command_error(ctx, error):
     raise error
 
 
+@bot.tree.error
+async def on_app_command_error(interaction: discord.Interaction, error: discord.app_commands.AppCommandError):
+    if isinstance(error, discord.app_commands.errors.CommandOnCooldown):
+        await interaction.response.send_message(f'You are on cooldown. Try again in {round(error.retry_after)}s', ephemeral=True)
+    else:
+        raise error
+
 @bot.event
 async def setup_hook():
     for extension in initial_extensions:

--- a/mogi_objects.py
+++ b/mogi_objects.py
@@ -271,7 +271,7 @@ class JoinView(View):
         self.bottom_room_num = bottom_room_num
 
     @discord.ui.button(label="Join Room")
-    async def button_callback(self, interaction, button):
+    async def button_callback(self, interaction: discord.Interaction, button):
         await interaction.response.defer()
         muted_role_id = 434887701662007296
         restricted_role_id = 797208908153618452

--- a/mogi_objects.py
+++ b/mogi_objects.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import random
 import discord
 from datetime import datetime, timezone, timedelta
 import time
 from discord.ui import View
-from typing import List
+from typing import List, Callable
 
 
 class Mogi:
@@ -264,18 +266,17 @@ Winner: {format_[1]}
 
 
 class JoinView(View):
-    def __init__(self, room: Room, get_mmr, bottom_room_num):
+    def __init__(self, room: Room, get_mmr, bottom_room_num, is_restricted: Callable[[discord.User | discord.Member], bool] | None = None):
         super().__init__(timeout=1200)
         self.room = room
         self.get_mmr = get_mmr
         self.bottom_room_num = bottom_room_num
+        self.is_restricted = is_restricted
 
     @discord.ui.button(label="Join Room")
     async def button_callback(self, interaction: discord.Interaction, button):
         await interaction.response.defer()
-        muted_role_id = 434887701662007296
-        restricted_role_id = 797208908153618452
-        if interaction.user.get_role(muted_role_id) or interaction.user.get_role(restricted_role_id):
+        if self.is_restricted is not None and self.is_restricted(interaction.user):
             await interaction.followup.send(
                 "Players with the muted or restricted role cannot use the sub button.", ephemeral=True)
             return

--- a/prod_config.json
+++ b/prod_config.json
@@ -39,6 +39,11 @@
             792891432301625364,
             877629421811540016
     ],
+    "helper_staff_roles": [
+        389252697284542465,
+        399384750923579392,
+        399382503825211393
+    ],
     "queue_messages": true,
     "sec_between_queue_msgs": 2,
     "username": "username",

--- a/prod_config.json
+++ b/prod_config.json
@@ -44,6 +44,8 @@
         399384750923579392,
         399382503825211393
     ],
+    "restricted_role_id": 797208908153618452,
+    "muted_role_id": 434887701662007296,
     "queue_messages": true,
     "sec_between_queue_msgs": 2,
     "username": "username",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp==3.8.4
 discord.py==2.3.2
 python-dateutil==2.8.2
+dill~=0.3.8

--- a/test_config.json
+++ b/test_config.json
@@ -38,6 +38,11 @@
             792891432301625364,
             877629421811540016
     ],
+    "helper_staff_roles": [
+        389252697284542465,
+        399384750923579392,
+        399382503825211393
+    ],
     "queue_messages": true,
     "sec_between_queue_msgs": 2,
     "username": "username",

--- a/test_config.json
+++ b/test_config.json
@@ -43,6 +43,8 @@
         399384750923579392,
         399382503825211393
     ],
+    "restricted_role_id": 797208908153618452,
+    "muted_role_id": 434887701662007296,
     "queue_messages": true,
     "sec_between_queue_msgs": 2,
     "username": "username",


### PR DESCRIPTION
This PR does the following:
- If staff changes the mmr threshold, it will be saved to disk. It will be loaded in when the bot starts. If there is no saved mmr threshold on disk, the bot will load the mmr threshold from the configuration.
- Added a `/ping_staff` command, which will allow players in threads (who are not muted or restricted) to ping the roles listed in the config's `helper_staff_roles`. This command has a 5 minute cooldown per user.
- Refactored how muted and restricted roles are checked.

All changes have been tested to the best of my ability.