### PR TITLE
All room invalid range algorithm + bug fixes

### DIFF
--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -1309,7 +1309,7 @@ If you need staff's assistance, use the `/ping_staff` command in this channel.""
             elif common.SERVER is common.Server.MKW:
                 member = await self.bot.fetch_user(433353529655296011)
         for i, rating in enumerate(ratings, 1):
-            if rating.isdecimal():
+            if common.is_int(rating):
                 player = Player(member, f"{member.name} {i}", int(
                     rating), confirmed=True)
                 mogi.teams.append(Team([player]))

--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -1330,7 +1330,7 @@ If you need staff's assistance, use the `/ping_staff` command in this channel.""
             return
 
         member = ctx.author
-        if self.is_production:
+        if not self.is_production:
             if common.SERVER is common.Server.MK8DX:
                 member = await self.bot.fetch_user(318637887597969419)
             elif common.SERVER is common.Server.MKW:

--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -150,9 +150,6 @@ class SquadQueue(commands.Cog):
 
         self.ratings = mmr.Ratings()
 
-        # Parameters for tracking if we should send an extension message or not
-        self.last_extension_message_timestamp = datetime.now(timezone.utc).replace(second=0, microsecond=0)
-        self.cur_extension_message = None
 
     @commands.Cog.listener()
     async def on_ready(self):

--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -298,7 +298,8 @@ class SquadQueue(commands.Cog):
                 # is actually a user and not a member
                 member = await self.bot.fetch_user(318637887597969419)
             elif common.SERVER is common.Server.MKW:
-                member = await self.bot.fetch_user(82862780591378432)
+                # member = await self.bot.fetch_user(82862780591378432)
+                pass
         mogi = self.get_mogi(interaction)
         if mogi is None or not mogi.started or not mogi.gathering:
             await interaction.response.send_message("Queue has not started yet.")

--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -1303,7 +1303,7 @@ If you need staff's assistance, use the `/ping_staff` command in this channel.""
                 or not await self.is_gathering(ctx, mogi)):
             return
         member = ctx.author
-        if self.is_production:
+        if not self.is_production:
             if common.SERVER is common.Server.MK8DX:
                 member = await self.bot.fetch_user(318637887597969419)
             elif common.SERVER is common.Server.MKW:

--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -1068,10 +1068,21 @@ If you need staff's assistance, use the `/ping_staff` command in this channel.""
             elif mogi.start_time <= cur_time and mogi.gathering:
                 # check if there are an even amount of teams since we are past the queue time
                 num_leftover_teams = mogi.count_registered() % (12 // mogi.max_player_per_team)
+                # If have en even number of players...
                 if num_leftover_teams == 0:
-                    mogi.gathering = False
-                    self.cur_extension_message = None
-                    return True
+                    # ...and none of the rooms will be cancelled, close the queue and begin
+                    if not mogi.any_room_cancelled(self.allowed_players_check):
+                        mogi.gathering = False
+                        self.cur_extension_message = None
+                        return True
+                    # ...any of the rooms will be cancelled, set the error message
+                    else:
+                        self.last_extension_message_timestamp = datetime.now(timezone.utc).replace(second=0, microsecond=0)
+                        minutes_left = (force_start_time - cur_time).seconds // 60
+                        self.cur_extension_message = f"One or more of the rooms will be cancelled, so the extension " \
+                                                     f"will continue. Starting in {minutes_left + 1} minute(s) " \
+                                                     f"regardless."
+
                 else:
                     cur_extension_timestamp = datetime.now(timezone.utc).replace(second=0, microsecond=0)
                     # At this point, we're in the extension time. So if the extension timestamp is in a different

--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -1067,8 +1067,7 @@ If you need staff's assistance, use the `/ping_staff` command in this channel.""
                 return True
             elif mogi.start_time <= cur_time and mogi.gathering:
                 # check if there are an even amount of teams since we are past the queue time
-                num_leftover_teams = mogi.count_registered() % int(
-                    (12 / mogi.max_player_per_team))
+                num_leftover_teams = mogi.count_registered() % (12 // mogi.max_player_per_team)
                 if num_leftover_teams == 0:
                     mogi.gathering = False
                     self.cur_extension_message = None

--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -66,6 +66,10 @@ class SquadQueue(commands.Cog):
 
         self.sq_times = []
 
+        # Parameters for tracking if we should send an extension message or not
+        self.last_extension_message_timestamp = datetime.now(timezone.utc).replace(second=0, microsecond=0)
+        self.cur_extension_message = None
+
         self._scheduler_task = self.sqscheduler.start()
         self._msgqueue_task = self.send_queued_messages.start()
         self._list_task = self.list_task.start()

--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -939,6 +939,8 @@ class SquadQueue(commands.Cog):
             return
         if mogi.making_rooms_run and started_automatically:
             return
+
+        await self.lockdown(mogi.mogi_channel)
         if mogi.max_possible_rooms == 0:
             self.ongoing_event = None
             await mogi.mogi_channel.send(f"Not enough players to fill a single room! This mogi will be cancelled.")
@@ -950,7 +952,6 @@ class SquadQueue(commands.Cog):
 
         await self.check_room_channels(mogi)
 
-        await self.lockdown(mogi.mogi_channel)
         if was_gathering:
             await mogi.mogi_channel.send("Mogi is now closed; players can no longer join or drop from the event")
 

--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -136,6 +136,10 @@ class SquadQueue(commands.Cog):
                                                  tzinfo=timezone.utc) + timedelta(
             minutes=bot.config["FIRST_EVENT_TIME"])
 
+        # If we're testing, set the time to the current time so we start a new event immediately
+        if not self.is_production:
+            self.FIRST_EVENT_TIME = datetime.now(timezone.utc)
+
         with open('./timezones.json', 'r') as cjson:
             self.timezones = json.load(cjson)
 

--- a/common.py
+++ b/common.py
@@ -32,3 +32,11 @@ def flatten(matrix: List[List[_T]]) -> List[_T]:
     for row in matrix:
         flat_list.extend(row)
     return flat_list
+
+
+def is_int(var: str) -> bool:
+    try:
+        int(var)
+        return True
+    except ValueError:
+        return False

--- a/mogi_objects.py
+++ b/mogi_objects.py
@@ -99,15 +99,17 @@ class Mogi:
                 break
             cur_check_list.append(late_players.pop(0))
         # Even after checking the late players, we did not find
-        return [], Mogi.ALGORITHM_STATUS_SUCCESS_EMPTY
+        return best_collection, Mogi.ALGORITHM_STATUS_SUCCESS_EMPTY
 
     def _mk8dx_generate_final_list(self) -> List[Player]:
         confirmed_players = self.players_on_confirmed_teams()
         return confirmed_players[0:self.players_per_room * self.max_possible_rooms]
 
     def _mkw_generate_final_list(self, valid_players_check: Callable[[List[Player]], bool]) -> List[Player]:
-        result, _ = self._one_room_final_list_algorithm(valid_players_check)
-        return result
+        result, status = self._all_room_final_list_algorithm(valid_players_check)
+        if status is Mogi.ALGORITHM_STATUS_INSUFFICIENT_PLAYERS:
+            return self.players_on_confirmed_teams()
+        return sorted(common.flatten(result), reverse=True)  # I do not want to formally prove that sorting here is correct
 
     def generate_proposed_list(self, valid_players_check: Callable[[List[Player]], bool] = None) -> List[Player]:
         """Algorithm that generates a proposed list of players that will play. This algorithm may differ between

--- a/mogi_objects.py
+++ b/mogi_objects.py
@@ -84,7 +84,7 @@ class Mogi:
             return [], Mogi.ALGORITHM_STATUS_INSUFFICIENT_PLAYERS
         if self.max_possible_rooms > 1:
             confirmed_players = self.players_on_confirmed_teams()
-            return confirmed_players[0:self.players_per_room * self.max_possible_rooms], Mogi.ALGORITHM_STATUS_2_OR_MORE_ROOMS
+            return sorted(confirmed_players[0:self.players_per_room * self.max_possible_rooms], reverse=True), Mogi.ALGORITHM_STATUS_2_OR_MORE_ROOMS
         # At this point, we can only make one possible room, so our algorithm will be used
         confirmed_players = self.players_on_confirmed_teams()
         cur_check_list = list(confirmed_players[0:self.players_per_room])
@@ -94,7 +94,7 @@ class Mogi:
             best_collection = Mogi._minimize_range(
                 cur_check_list, self.players_per_room)
             if valid_players_check(best_collection):
-                return best_collection, Mogi.ALGORITHM_STATUS_SUCCESS_FOUND
+                return sorted(best_collection, reverse=True), Mogi.ALGORITHM_STATUS_SUCCESS_FOUND
             if len(late_players) == 0:
                 break
             cur_check_list.append(late_players.pop(0))
@@ -103,7 +103,9 @@ class Mogi:
 
     def _mk8dx_generate_final_list(self) -> List[Player]:
         confirmed_players = self.players_on_confirmed_teams()
-        return confirmed_players[0:self.players_per_room * self.max_possible_rooms]
+        if self.max_possible_rooms == 0:
+            return confirmed_players
+        return sorted(confirmed_players[0:self.players_per_room * self.max_possible_rooms], reverse=True)
 
     def _mkw_generate_final_list(self, valid_players_check: Callable[[List[Player]], bool]) -> List[Player]:
         result, status = self._all_room_final_list_algorithm(valid_players_check)

--- a/mogi_objects.py
+++ b/mogi_objects.py
@@ -79,6 +79,36 @@ class Mogi:
                                                  lowest_player_index + num_players]
         return best_collection
 
+
+
+    def _all_room_final_list_algorithm(self, valid_players_check: Callable[[List[Player]], bool]) -> Tuple[List[List[Player]], int]:
+        if self.max_possible_rooms == 0:
+            return [], Mogi.ALGORITHM_STATUS_INSUFFICIENT_PLAYERS
+        all_confirmed_players = self.players_on_confirmed_teams()
+        first_late_player_index = (self.num_players // self.players_per_room) * self.players_per_room
+        on_time_players = sorted(all_confirmed_players[:first_late_player_index], reverse=True)
+        late_players = all_confirmed_players[first_late_player_index:]
+        player_rooms: List[List[Player]] = list(common.divide_chunks(on_time_players, self.players_per_room))
+
+        any_invalid = False
+        for pr_index, player_room in enumerate(player_rooms, 0):
+            for lp_index in range(len(late_players)+1):
+                current_late_check_players = late_players[0:lp_index]
+                best_collection = Mogi._minimize_range(player_room + current_late_check_players, self.players_per_room)
+                if valid_players_check(best_collection):
+                    best_collection.sort(reverse=True)
+                    # Get all the players who were swapped out of the room and put them at the front of the late player list
+                    swapped_out_players = [p for p in player_room if p not in best_collection]
+                    swapped_in_players = [p for p in best_collection if p not in player_room]
+                    late_players = swapped_out_players + list(filter(lambda p: p not in swapped_in_players, late_players))
+                    player_rooms[pr_index] = best_collection
+                    break
+            else:
+                # After checking all late players, no room player list with a valid range could be found for this room
+                any_invalid = True
+
+        return player_rooms, (Mogi.ALGORITHM_STATUS_SUCCESS_SOME_INVALID if any_invalid else Mogi.ALGORITHM_STATUS_SUCCESS_FOUND)
+
     def _one_room_final_list_algorithm(self, valid_players_check: Callable[[List[Player]], bool]) -> Tuple[List[Player], int]:
         if self.max_possible_rooms == 0:
             return [], Mogi.ALGORITHM_STATUS_INSUFFICIENT_PLAYERS

--- a/mogi_objects.py
+++ b/mogi_objects.py
@@ -79,6 +79,33 @@ class Mogi:
                                                  lowest_player_index + num_players]
         return best_collection
 
+    def _OLD_all_room_final_list_algorithm(self, valid_players_check: Callable[[List[Player]], bool]) -> Tuple[List[List[Player]], int]:
+        if self.max_possible_rooms == 0:
+            return [], Mogi.ALGORITHM_STATUS_INSUFFICIENT_PLAYERS
+        all_confirmed_players = self.players_on_confirmed_teams()
+        first_late_player_index = (self.num_players // self.players_per_room) * self.players_per_room
+        on_time_players = sorted(all_confirmed_players[:first_late_player_index], reverse=True)
+        late_players = all_confirmed_players[first_late_player_index:]
+        player_rooms: List[List[Player]] = list(common.divide_chunks(on_time_players, self.players_per_room))
+
+        any_invalid = False
+        for pr_index, player_room in enumerate(player_rooms, 0):
+            for lp_index in range(len(late_players)+1):
+                current_late_check_players = late_players[0:lp_index]
+                best_collection = Mogi._minimize_range(player_room + current_late_check_players, self.players_per_room)
+                if valid_players_check(best_collection):
+                    best_collection.sort(reverse=True)
+                    # Get all the players who were swapped out of the room and put them at the front of the late player list
+                    swapped_out_players = [p for p in player_room if p not in best_collection]
+                    swapped_in_players = [p for p in best_collection if p not in player_room]
+                    late_players = swapped_out_players + list(filter(lambda p: p not in swapped_in_players, late_players))
+                    player_rooms[pr_index] = best_collection
+                    break
+            else:
+                # After checking all late players, no room player list with a valid range could be found for this room
+                any_invalid = True
+
+        return player_rooms, (Mogi.ALGORITHM_STATUS_SUCCESS_SOME_INVALID if any_invalid else Mogi.ALGORITHM_STATUS_SUCCESS_FOUND)
 
 
     def _all_room_final_list_algorithm(self, valid_players_check: Callable[[List[Player]], bool]) -> Tuple[List[List[Player]], int]:


### PR DESCRIPTION
This PR contains the following:

**Breaking bugs in production:**
1. debug function had incorrect check: https://github.com/emilp-595/QueueBot/pull/26/commits/d13362bfa65e02756ea0649b9c0065e3c633f15e
2. debug function had incorrect check: https://github.com/emilp-595/QueueBot/pull/26/commits/6ea903abaea6192b8b96b27134435f9a27567df5

**Bug fixes:**
- Bot would not lockdown channel when not enough rooms
- Negative readings would not read in in debug function `debug_add_many_ratings`
- Players no longer show as all removed when there aren't enough rooms. The regular cancel message is displayed.

**Refactors:**
- Moved `check_valid_players` to be `SquadQueue` function

**Features:**
- For both MKW and MK8DX: the queue does not close during extension if a room that would be cancelled would occur. (After extension has ended, rooms are made and cancelled as necessary. No changes here.) Finishes pam's comment on #8 
- For MKW: an algorithm that handles any number of rooms being cancelled by swapping in players: Finished: #23 

**Other:**
- I moved the definition up of two `SquadQueue` class variables as I got a traceback that they weren't defined. But after later review and reverting, I could not replicate. Although I don't think there is an issue with defining them later, I am leaving the commits in:
1. https://github.com/emilp-595/QueueBot/pull/26/commits/38bf1461b9fea099aa4c430aa7068b3b21842625
2. https://github.com/emilp-595/QueueBot/pull/26/commits/d59d4e6b56819f2b0e5f6dad2e556ef99bec98c5